### PR TITLE
Add support to autoupdate task definition on service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Module directory
 .terraform/
+
+.idea/

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,8 @@ resource "aws_ecs_service" "ecs_service" {
   launch_type      = "FARGATE"
   platform_version = "${var.platform_version}"
 
-  task_definition = "${aws_ecs_task_definition.task_def.arn}"
+  # Track the latest ACTIVE revision
+  task_definition = "${aws_ecs_task_definition.task_def.family}:${max("${aws_ecs_task_definition.task_def.revision}", "${data.aws_ecs_task_definition.task_def.revision}")}"
 
   health_check_grace_period_seconds = "${var.health_check_grace_period_seconds}"
 
@@ -70,7 +71,6 @@ resource "aws_ecs_service" "ecs_service" {
   lifecycle {
     ignore_changes = [
       "desired_count",
-      "task_definition",
     ]
   }
 }
@@ -113,4 +113,8 @@ resource "aws_cloudwatch_log_group" "log_group" {
   retention_in_days = "${var.log_retention_in_days}"
 
   tags = "${merge(local.global_tags, var.log_tags)}"
+}
+
+data "aws_ecs_task_definition" "task_def" {
+  task_definition = "${aws_ecs_task_definition.task_def.family}"
 }


### PR DESCRIPTION
Issue:
Whenever a new task definition is created, the Fargate service ignores the new version which results in old task definition running on Fargate Service. E.g: Latest version on task definition: 40 - containing changes such as adding environment varibale, but active version on service: 39
Post above, whenever codepipeline is deployed, it picks up the task definition 39 (the current active task) and replicates it, which means the changes in version 40 are lost.

Resolution:
1. Remove the block of ignoring the change on task definition
2. To ensure our fargate detects the change in task definition and terraform does not detect change on version bump up for redeploy, get the max of current task definition vs the task definition in our infra.

References: https://github.com/hashicorp/terraform/issues/4378 and https://www.terraform.io/docs/providers/aws/d/ecs_task_definition.html