### PR TITLE
Fix the dependency issue of data task with resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_ecs_service" "ecs_service" {
   platform_version = "${var.platform_version}"
 
   # Track the latest ACTIVE revision
-  task_definition = "${aws_ecs_task_definition.task_def.family}:${max("${aws_ecs_task_definition.task_def.revision}", "${data.aws_ecs_task_definition.task_def.revision}")}"
+  task_definition = "${aws_ecs_task_definition.task_def.family}:${max("${aws_ecs_task_definition.task_def.revision}", "${data.aws_ecs_task_definition.task_def_data.revision}")}"
 
   health_check_grace_period_seconds = "${var.health_check_grace_period_seconds}"
 
@@ -115,6 +115,7 @@ resource "aws_cloudwatch_log_group" "log_group" {
   tags = "${merge(local.global_tags, var.log_tags)}"
 }
 
-data "aws_ecs_task_definition" "task_def" {
+data "aws_ecs_task_definition" "task_def_data" {
+  depends_on = [ "aws_ecs_task_definition.task_def" ]
   task_definition = "${aws_ecs_task_definition.task_def.family}"
 }

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,6 @@ resource "aws_cloudwatch_log_group" "log_group" {
 }
 
 data "aws_ecs_task_definition" "task_def_data" {
-  depends_on = [ "aws_ecs_task_definition.task_def" ]
+  depends_on      = ["aws_ecs_task_definition.task_def"]
   task_definition = "${aws_ecs_task_definition.task_def.family}"
 }


### PR DESCRIPTION
This PR fixes the dependency issue being faced while creating a new fargate service as described below:
```
module.fargate_service.module.service.data.aws_ecs_task_definition.task_def: data.aws_ecs_task_definition.task_def: Failed getting task definition ClientException: Unable to describe task definition.
   status code: 400, request id: e773a56d-b697-4890-81d9-61bf8d34f5c6 “ecibpui-app-7c448977f1e6ac05”
```
Ref: https://github.com/terraform-providers/terraform-provider-aws/issues/1274#issuecomment-331332157

**Note**: The issue is intermediate and might not always be reproducible