### PR TITLE
Expose launch_type as variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,11 @@ resource "aws_ecs_service" "ecs_service" {
   cluster       = "${var.ecs_cluster_arn}"
   desired_count = "${var.capacity}"
 
-  launch_type      = "FARGATE"
+  # Hack, so we can fill it with empty "" to prevent destroying
+  # resources with capacity_provider_strategy enabled via web console.
+  # capacity_provider_strategy is only available in aws provider > 2.42.0
+  launch_type = "${var.launch_type}"
+
   platform_version = "${var.platform_version}"
 
   # Track the latest ACTIVE revision

--- a/variables.tf
+++ b/variables.tf
@@ -148,3 +148,9 @@ variable "log_tags" {
   type        = "map"
   default     = {}
 }
+
+variable "launch_type" {
+  description = "The launch type on which to run your service. The valid values are \"\", EC2 and FARGATE"
+  type        = "string"
+  default     = "FARGATE"
+}


### PR DESCRIPTION
To optimize cost, currently we use ecs `capacity_provider_strategy` which enables us to use `FARGATE_SPOT` and `FARGATE`. Unfortunately, this feature is only available in `aws` provider version 2.42.0 and we cannot update it because we have some dependencies that require lower aws provider version.

This change will enable user to specify `launch_type = ""` so that it won't destroy already optimized ecs services while maintaining default `launch_type = "FARGATE"`.