### PR TITLE
Add enable_execute_command arg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ resource "aws_ecs_service" "ecs_service" {
   task_definition = aws_ecs_task_definition.task_def.family
 
   health_check_grace_period_seconds = var.health_check_grace_period_seconds
+  enable_execute_command = var.enable_execute_command
 
   network_configuration {
     subnets          = var.subnet_ids

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "use_latest_task_definition" {
   default     = true
 }
 
+variable "enable_execute_command" {
+  description = "Specifies whether to enable Amazon ECS Exec for the tasks within the service"
+  type        = bool
+  default     = false
+} 
+
 variable "main_container_name" {
   description = "Name of the container name that will be registered to target group"
   type        = string


### PR DESCRIPTION
Support the `enable_execute_command` arg from [official ecs service module](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service).

This supports many use cases, one of which is the ability to enter a container to debug. Default is false unless the user knows what they are doing. 