### PR TITLE
[bcp] add random-name as output to fix cyclic reference

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,13 @@ output "taskdef_arn" {
   value       = aws_ecs_task_definition.task_def.arn
   description = "The full ARN of the task definition"
 }
+
+output "resource_naming_service" {
+  value       = module.service_name.name
+  description = "The ecs service name from resource-naming, use this as reference value to avoid cyclic reference"
+}
+
+output "resource_naming_taskdef" {
+  value       = module.taskdef_name.name
+  description = "The task definition name from resource-naming, use this as reference value to avoid cyclic reference"
+}


### PR DESCRIPTION
## Summary 

Similar to #31 but for `codedeploy` branch.


## Testing Result

```hcl
...
                  ~ image            = "015110552125.dkr.ecr.ap-southeast-1.amazonaws.com/ewlccg-app:latest" -> "015110552125.dkr.ecr.ap-southeast-1.amazonaws.com/ewlccg-app:ab5b62e"
                  ~ logConfiguration = {
                      ~ options   = {
                          ~ awslogs-stream-prefix = "latest" -> "ab5b62e"
                            # (2 unchanged elements hidden)
                        }
                        # (1 unchanged element hidden)
                    }
                    # (9 unchanged elements hidden)
```

> Note: truncated for readability, for full plan refer here: https://github.com/traveloka/tvlk-ewl-stg-terraform-aws/pull/979#issuecomment-1573358365