### PR TITLE
Add support to attach multiple target_group via secondary_target_group_arn

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,12 @@ variable "target_group_arn" {
   type        = string
 }
 
+variable "secondary_target_group_arn" {
+  description = "ARN of the 2nd ALB target group to associate with the service"
+  type        = string
+  default     = ""
+}
+
 variable "image_name" {
   description = "Name of the docker image that will be used by the task"
   type        = string


### PR DESCRIPTION
## Summary
(ECI) BPNG team has a need to migrate our ECS service from NLB to ALB. 
The strategy is using multiple target groups where we will attach our current service with the new target group (from ALB) so the service will be running both with ALB and NLB.
We will use route53 to control the traffic and route it into ALB step-by-step until 100%.

AWS now enable us to update LB of the existing service, also support to attach it with up-to 5 target groups which make the strategy possbile. 
- https://aws.amazon.com/about-aws/whats-new/2019/07/amazon-ecs-services-now-support-multiple-load-balancer-target-groups/
- https://aws.amazon.com/about-aws/whats-new/2022/03/amazon-ecs-service-api-updating-elastic-load-balancers-service-registries-tag-propagation-ecs-managed-tags/

## Test Plan
The strategy has been tested by applying changes manually in local
